### PR TITLE
fix: Center navbar navigation ignoring logo position

### DIFF
--- a/html-template/common/header.html
+++ b/html-template/common/header.html
@@ -28,7 +28,7 @@ $def with (sp_title, current_subdomain)
      
       <!-- Main navigation menu -->
       <div class="collapse navbar-collapse justify-content-center" id="navbarNav">
-        <ul class="navbar-nav">
+        <ul class="navbar-nav navbar-nav-centered">
           <!-- Search -->
           <li class="nav-item">
             <a class="nav-link fw-semibold px-3 ${'active' if current_subdomain == 'search' else ''}"

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -184,6 +184,13 @@ main {
     display: block;
     animation: fadeIn 0.2s ease;
   }
+
+  /* Center navigation menu ignoring logo position only on desktop */
+  .navbar-nav-centered {
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+  }
   
   @keyframes fadeIn {
     from {
@@ -205,13 +212,4 @@ main {
 /* Remove default Bootstrap dropdown arrow from main links */
 .nav-link-main::after {
   display: none !important;
-}
-
-/* Center navigation menu ignoring logo position only on desktop */
-@media (min-width: 992px) {
-  .navbar-nav-centered {
-    position: absolute;
-    left: 50%;
-    transform: translateX(-50%);
-  }
 }

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -206,3 +206,12 @@ main {
 .nav-link-main::after {
   display: none !important;
 }
+
+/* Center navigation menu ignoring logo position only on desktop */
+@media (min-width: 992px) {
+  .navbar-nav-centered {
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+  }
+}


### PR DESCRIPTION
- Add navbar-nav-centered class to center menu items
- Apply centering only on desktop (min-width: 992px) to preserve mobile hamburger functionality
- Modify common header template
- Add responsive CSS rule to custom.css